### PR TITLE
Rename this dojo

### DIFF
--- a/dojo.yml
+++ b/dojo.yml
@@ -1,6 +1,6 @@
-id: robwaz-dojo
+id: arm-architecture
 
-name: ARM Dojo
+name: ARM Architecture
 type: public
 
 award:


### PR DESCRIPTION
This means that instead of https://pwn.college/robwaz-dojo, this would appear at https://pwn.college/arm-architecture. Probably this is a little more semantically meaningful, but certainly not as authorially meaningful :(